### PR TITLE
fix: starter cost font

### DIFF
--- a/style/speciesPanel.css
+++ b/style/speciesPanel.css
@@ -6,7 +6,7 @@
 	letter-spacing: -0.3px;
 }
 
-.starterCost {
+#speciesEggGroups .starterCost {
 	font-weight: bold;
 	font-size: 25px;
 }


### PR DESCRIPTION
From this https://github.com/ydarissep/dex-core/pull/1

The starter cost on the species table font is bigger than usual this PR fix it